### PR TITLE
Populate Date header if none supplied

### DIFF
--- a/common.go
+++ b/common.go
@@ -56,7 +56,7 @@ func BuildSignatureString(req *http.Request, headers []string) string {
 			values = append(values, fmt.Sprintf("%s: %s", h, req.Host))
 		case "date":
 			if req.Header.Get(h) == "" {
-				req.Header.Set(h, time.Now().Format(time.RFC1123))
+				req.Header.Set(h, time.Now().UTC().Format(http.TimeFormat))
 			}
 			values = append(values, fmt.Sprintf("%s: %s", h, req.Header.Get(h)))
 		default:

--- a/common.go
+++ b/common.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 var (
@@ -53,6 +54,11 @@ func BuildSignatureString(req *http.Request, headers []string) string {
 				h, strings.ToLower(req.Method), requestPath(req)))
 		case "host":
 			values = append(values, fmt.Sprintf("%s: %s", h, req.Host))
+		case "date":
+			if req.Header.Get(h) == "" {
+				req.Header.Set(h, time.Now().Format(time.RFC1123))
+			}
+			values = append(values, fmt.Sprintf("%s: %s", h, req.Header.Get(h)))
 		default:
 			for _, value := range req.Header[http.CanonicalHeaderKey(h)] {
 				values = append(values,


### PR DESCRIPTION
By default, the Date header is included in the list of signed headers, though it might not exist on the request. This patch ensures the header is always there.