### PR TITLE
hs2019 with PSS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ If signature validation fails, a `401` is returned along with a
 
 ## Supported algorithms
 
+- hs2019 (using PSS)
+
+### Deprecated algorithms
 - rsa-sha1 (using PKCS1v15)
 - rsa-sha256 (using PKCS1v15)
 - hmac-sha256

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ because the type required for the algorithm is known).
 
 ```
 var key *rsa.PrivateKey = ...
-signer := httpsig.NewHS2019Signer("foo", key, nil)
+signer := httpsig.NewHS2019PSSSigner("foo", key, nil)
 ```
 
 By default, if no headers are passed to `NewSigner` (or the helpers), the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ because the type required for the algorithm is known).
 
 ```
 var key *rsa.PrivateKey = ...
-signer := httpsig.NewHS2019PSSSigner("foo", key, nil)
+signer := httpsig.NewHS2019PSSSigner("foo", key, nil, rsa.PSSSaltLengthEqualsHash)
 ```
 
 By default, if no headers are passed to `NewSigner` (or the helpers), the
@@ -101,7 +101,7 @@ keystore.SetKey("foo", hmac_key)
 In order to support hs2019 the keystore also includes a store for the key 
 algorithm. Key algorithms can be added using the SetKeyAlgorithm method:
 ```
-keystore.SetKeyAlgorithm("foo", algorithm.HS2019_PSS)
+keystore.SetKeyAlgorithm("foo", NewHS2019_PSS(rsa.PSSSaltLengthEqualHash))
 ``` 
 
 ## Handler

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Signing requests is done by constructing a new `Signer`. The key id, key,
 algorithm, and what headers to sign are required.
 
 For example to construct a `Signer` with key id `"foo"`, using an RSA private
-key, for the rsa-sha256 algorithm, with the default header set, you can do:
+key, for the hs2019 algorithm and RSA key (PSS), with the default header set, you can do:
 
 ```
 var key *rsa.PrivateKey = ...
-signer := httpsig.NewSigner("foo", key, httpsig.RSASHA256, nil)
+signer := httpsig.NewSigner("foo", key, httpsig.HS1029_PSS, nil)
 ```
 
 There are helper functions for specific algorithms that are less verbose and
@@ -31,7 +31,7 @@ because the type required for the algorithm is known).
 
 ```
 var key *rsa.PrivateKey = ...
-signer := httpsig.NewRSASHA256Signer("foo", key, nil)
+signer := httpsig.NewHS2019Signer("foo", key, nil)
 ```
 
 By default, if no headers are passed to `NewSigner` (or the helpers), the
@@ -49,7 +49,7 @@ fmt.Println("AUTHORIZATION:", req.Header.Get('Authorization'))
 
 ...
 
-AUTHORIZATION: Signature: keyId="foo",algorithm="sha-256",signature="..."
+AUTHORIZATION: Signature: keyId="foo",algorithm="hs2019",signature="..."
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ var hmac_key []byte = ...
 keystore.SetKey("foo", hmac_key)
 ```
 
+In order to support hs2019 the keystore also includes a store for the key 
+algorithm. Key algorithms can be added using the SetKeyAlgorithm method:
+```
+keystore.SetKeyAlgorithm("foo", algorithm.HS2019_PSS)
+``` 
+
 ## Handler
 
 A convenience function is provided that wraps an `http.Handler` and verifies

--- a/handler_test.go
+++ b/handler_test.go
@@ -136,7 +136,7 @@ func TestHandlerAcceptsSignedRequest(t *testing.T) {
 	req, err := http.NewRequest("GET", server.URL, nil)
 	test.AssertNoError(err)
 
-	s := NewRSASHA256Signer("Test", test.PrivateKey, v.RequiredHeaders())
+	s := NewHS2019PSSSigner("Test", test.PrivateKey, v.RequiredHeaders())
 	test.AssertNoError(s.Sign(req))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/handler_test.go
+++ b/handler_test.go
@@ -15,6 +15,7 @@
 package httpsig
 
 import (
+	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -136,7 +137,7 @@ func TestHandlerAcceptsSignedRequest(t *testing.T) {
 	req, err := http.NewRequest("GET", server.URL, nil)
 	test.AssertNoError(err)
 
-	s := NewHS2019PSSSigner("Test", test.PrivateKey, v.RequiredHeaders())
+	s := NewHS2019PSSSigner("Test", test.PrivateKey, v.RequiredHeaders(), rsa.PSSSaltLengthAuto)
 	test.AssertNoError(s.Sign(req))
 
 	resp, err := http.DefaultClient.Do(req)

--- a/hs2019.go
+++ b/hs2019.go
@@ -7,15 +7,15 @@ import (
 
 
 // HS2019 implements PSS signatures over a SHA512 digest
-var HS2019_PSS Algorithm = hs_2019_pss{}
+var HS2019_PSS Algorithm = hs2019_pss{}
 
-type hs_2019_pss struct{}
+type hs2019_pss struct{}
 
-func (hs_2019_pss) Name() string {
+func (hs2019_pss) Name() string {
 	return "hs2019_pss"
 }
 
-func (a hs_2019_pss) Sign(key interface{}, data []byte) ([]byte, error) {
+func (a hs2019_pss) Sign(key interface{}, data []byte) ([]byte, error) {
 	k := toRSAPrivateKey(key)
 	if k == nil {
 		return nil, unsupportedAlgorithm(a)
@@ -23,7 +23,7 @@ func (a hs_2019_pss) Sign(key interface{}, data []byte) ([]byte, error) {
 	return RSASignPSS(k, crypto.SHA512, data)
 }
 
-func (a hs_2019_pss) Verify(key interface{}, data, sig []byte) error {
+func (a hs2019_pss) Verify(key interface{}, data, sig []byte) error {
 	k := toRSAPublicKey(key)
 	if k == nil {
 		return unsupportedAlgorithm(a)

--- a/hs2019.go
+++ b/hs2019.go
@@ -39,7 +39,8 @@ func RSASignPSS(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
 	if _, err := h.Write(data); err != nil {
 		return nil, err
 	}
-	return rsa.SignPSS(Rand, key, hash, h.Sum(nil), nil)
+	opt := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash}
+	return rsa.SignPSS(Rand, key, hash, h.Sum(nil), opt)
 }
 
 // RSAVerifyPSS verifies a signed digest of the data hashed using the provided hash
@@ -50,5 +51,6 @@ func RSAVerifyPSS(key *rsa.PublicKey, hash crypto.Hash, data, sig []byte) (
 	if _, err := h.Write(data); err != nil {
 		return err
 	}
-	return rsa.VerifyPSS(key, hash, h.Sum(nil), sig, nil)
+	opt := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash}
+	return rsa.VerifyPSS(key, hash, h.Sum(nil), sig, opt)
 }

--- a/hs2019.go
+++ b/hs2019.go
@@ -12,7 +12,7 @@ var HS2019_PSS Algorithm = hs2019_pss{}
 type hs2019_pss struct{}
 
 func (hs2019_pss) Name() string {
-	return "hs2019_pss"
+	return "hs2019"
 }
 
 func (a hs2019_pss) Sign(key interface{}, data []byte) ([]byte, error) {

--- a/hs2019.go
+++ b/hs2019.go
@@ -5,15 +5,12 @@ import (
 	"crypto/rsa"
 )
 
-// HS2019 implements PSS signatures over a SHA512 digest
-var HS2019_PSS Algorithm = hs2019_pss{}
-
 type hs2019_pss struct {
 	saltLength int
 	hash       crypto.Hash
 }
 
-func (hs2019_pss) HS2019_PSS(saltLenght int) *hs2019_pss {
+func NewHS2019_PSS(saltLenght int) *hs2019_pss {
 	return &hs2019_pss{
 		saltLength: saltLenght,
 		hash:       crypto.SHA512,
@@ -48,6 +45,6 @@ func (a hs2019_pss) Verify(key interface{}, data, sig []byte) error {
 	if _, err := h.Write(data); err != nil {
 		return err
 	}
-	opt := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash}
+	opt := &rsa.PSSOptions{SaltLength: a.saltLength}
 	return rsa.VerifyPSS(k, a.hash, h.Sum(nil), sig, opt)
 }

--- a/hs2019.go
+++ b/hs2019.go
@@ -1,0 +1,54 @@
+package httpsig
+
+import (
+	"crypto"
+	"crypto/rsa"
+)
+
+
+// HS2019 implements PSS signatures over a SHA512 digest
+var HS2019_PSS Algorithm = hs_2019_pss{}
+
+type hs_2019_pss struct{}
+
+func (hs_2019_pss) Name() string {
+	return "hs2019_pss"
+}
+
+func (a hs_2019_pss) Sign(key interface{}, data []byte) ([]byte, error) {
+	k := toRSAPrivateKey(key)
+	if k == nil {
+		return nil, unsupportedAlgorithm(a)
+	}
+	return RSASignPSS(k, crypto.SHA512, data)
+}
+
+func (a hs_2019_pss) Verify(key interface{}, data, sig []byte) error {
+	k := toRSAPublicKey(key)
+	if k == nil {
+		return unsupportedAlgorithm(a)
+	}
+	return RSAVerifyPSS(k, crypto.SHA512, data, sig)
+}
+
+// RSASignPSS signs a digest of the data hashed using the provided hash
+func RSASignPSS(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
+	signature []byte, err error) {
+
+	h := hash.New()
+	if _, err := h.Write(data); err != nil {
+		return nil, err
+	}
+	return rsa.SignPSS(Rand, key, hash, h.Sum(nil), nil)
+}
+
+// RSAVerifyPSS verifies a signed digest of the data hashed using the provided hash
+func RSAVerifyPSS(key *rsa.PublicKey, hash crypto.Hash, data, sig []byte) (
+	err error) {
+
+	h := hash.New()
+	if _, err := h.Write(data); err != nil {
+		return err
+	}
+	return rsa.VerifyPSS(key, hash, h.Sum(nil), sig, nil)
+}

--- a/httpsig.go
+++ b/httpsig.go
@@ -32,6 +32,7 @@ type Algorithm interface {
 // Other types will treated as if no key was returned.
 type KeyGetter interface {
 	GetKey(id string) interface{}
+	GetAlgorithm(id string) Algorithm
 }
 
 // KeyGetterFunc is a convenience type for implementing a KeyGetter with a

--- a/httpsig.go
+++ b/httpsig.go
@@ -32,7 +32,7 @@ type Algorithm interface {
 // Other types will treated as if no key was returned.
 type KeyGetter interface {
 	GetKey(id string) interface{}
-	GetAlgorithm(id string) Algorithm
+	GetKeyAlgorithm(id string) Algorithm
 }
 
 // KeyGetterFunc is a convenience type for implementing a KeyGetter with a

--- a/httpsig_test.go
+++ b/httpsig_test.go
@@ -53,7 +53,6 @@ func TestDate(t *testing.T) {
 
 	signer := NewHS2019PSSSigner("Test", test.PrivateKey, []string{"date"})
 	verifier := NewVerifier(test)
-	verifier.algorithm = HS2019_PSS
 
 	req := test.NewRequest()
 	test.AssertNoError(signer.Sign(req))
@@ -83,7 +82,6 @@ func TestRequestTargetAndHost(t *testing.T) {
 	headers := []string{"(request-target)", "host", "date"}
 	signer := NewHS2019PSSSigner("Test", test.PrivateKey, headers)
 	verifier := NewVerifier(test)
-	verifier.algorithm = HS2019_PSS
 
 	req := test.NewRequest()
 	test.AssertNoError(signer.Sign(req))
@@ -121,22 +119,21 @@ func TestRequestTargetAndHost(t *testing.T) {
 func TestAlgorithmMismatch(t *testing.T) {
 	test := NewTest(t)
 
-	signer := NewHS2019PSSSigner("Test", test.PrivateKey, nil)
+	signer := NewRSASHA256Signer("Test", test.PrivateKey, nil)
 	verifier := NewVerifier(test)
-	verifier.algorithm = RSASHA256
 
 	req := test.NewRequest()
 	test.AssertNoError(signer.Sign(req))
 
 	err := verifier.Verify(req)
 	test.AssertAnyError(err)
-	test.AssertStringEqual(err.Error(),"algorithm header mismatch. Signature header value: hs2019, derived value: rsa-sha256")
+	test.AssertStringEqual(err.Error(),"algorithm header mismatch. Signature header value: rsa-sha256, derived value: hs2019")
 }
 
 func TestDeprecatedAlgorithm(t *testing.T) {
 	test := NewTest(t)
 
-	signer := NewRSASHA256Signer("Test", test.PrivateKey, nil)
+	signer := NewRSASHA256Signer("Test_SHA256", test.PrivateKey, nil)
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()
@@ -180,6 +177,9 @@ func NewTest(tb testing.TB) *Test {
 
 	keystore := NewMemoryKeyStore()
 	keystore.SetKey("Test", key)
+	keystore.SetKeyAlgorithm("Test", HS2019_PSS)
+
+	keystore.SetKey("Test_SHA256", key)
 
 	return &Test{
 		tb:         tb,
@@ -195,7 +195,7 @@ func (t *Test) NewRequest() *http.Request {
 	req.Header.Set("Date", "Thu, 05 Jan 2014 21:31:40 GMT")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Digest",
-		"SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=")
+		"SHA-512=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=")
 	return req
 }
 

--- a/httpsig_test.go
+++ b/httpsig_test.go
@@ -51,7 +51,7 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 func TestDate(t *testing.T) {
 	test := NewTest(t)
 
-	signer := NewRSASHA256Signer("Test", test.PrivateKey, []string{"date"})
+	signer := NewHS2019Signer("Test", test.PrivateKey, []string{"date"})
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()
@@ -80,7 +80,7 @@ func TestRequestTargetAndHost(t *testing.T) {
 	test := NewTest(t)
 
 	headers := []string{"(request-target)", "host", "date"}
-	signer := NewRSASHA256Signer("Test", test.PrivateKey, headers)
+	signer := NewHS2019Signer("Test", test.PrivateKey, headers)
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()

--- a/httpsig_test.go
+++ b/httpsig_test.go
@@ -51,7 +51,7 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 func TestDate(t *testing.T) {
 	test := NewTest(t)
 
-	signer := NewHS2019PSSSigner("Test", test.PrivateKey, []string{"date"})
+	signer := NewHS2019PSSSigner("Test", test.PrivateKey, []string{"date"}, rsa.PSSSaltLengthAuto)
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()
@@ -80,7 +80,7 @@ func TestRequestTargetAndHost(t *testing.T) {
 	test := NewTest(t)
 
 	headers := []string{"(request-target)", "host", "date"}
-	signer := NewHS2019PSSSigner("Test", test.PrivateKey, headers)
+	signer := NewHS2019PSSSigner("Test", test.PrivateKey, headers, rsa.PSSSaltLengthAuto)
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()
@@ -177,7 +177,7 @@ func NewTest(tb testing.TB) *Test {
 
 	keystore := NewMemoryKeyStore()
 	keystore.SetKey("Test", key)
-	keystore.SetKeyAlgorithm("Test", HS2019_PSS)
+	keystore.SetKeyAlgorithm("Test", NewHS2019_PSS(rsa.PSSSaltLengthAuto))
 
 	keystore.SetKey("Test_SHA256", key)
 

--- a/httpsig_test.go
+++ b/httpsig_test.go
@@ -51,7 +51,7 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 func TestDate(t *testing.T) {
 	test := NewTest(t)
 
-	signer := NewHS2019Signer("Test", test.PrivateKey, []string{"date"})
+	signer := NewHS2019PSSSigner("Test", test.PrivateKey, []string{"date"})
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()
@@ -80,7 +80,7 @@ func TestRequestTargetAndHost(t *testing.T) {
 	test := NewTest(t)
 
 	headers := []string{"(request-target)", "host", "date"}
-	signer := NewHS2019Signer("Test", test.PrivateKey, headers)
+	signer := NewHS2019PSSSigner("Test", test.PrivateKey, headers)
 	verifier := NewVerifier(test)
 
 	req := test.NewRequest()

--- a/keystore.go
+++ b/keystore.go
@@ -16,6 +16,7 @@ package httpsig
 
 type MemoryKeyStore struct {
 	keys map[string]interface{}
+	keyAlgorithms map[string]Algorithm
 }
 
 func NewMemoryKeyStore() *MemoryKeyStore {
@@ -30,4 +31,12 @@ func (m *MemoryKeyStore) GetKey(id string) interface{} {
 
 func (m *MemoryKeyStore) SetKey(id string, key interface{}) {
 	m.keys[id] = key
+}
+
+func (m *MemoryKeyStore) SetKeyAlgorithm(id string, algorithm Algorithm) {
+	m.keyAlgorithms[id] = algorithm
+}
+
+func (m *MemoryKeyStore) GetKeyAlgorithm(id string) Algorithm {
+	return m.keyAlgorithms[id]
 }

--- a/keystore.go
+++ b/keystore.go
@@ -22,6 +22,7 @@ type MemoryKeyStore struct {
 func NewMemoryKeyStore() *MemoryKeyStore {
 	return &MemoryKeyStore{
 		keys: make(map[string]interface{}),
+		keyAlgorithms: make(map[string]Algorithm),
 	}
 }
 

--- a/rsa.go
+++ b/rsa.go
@@ -69,6 +69,31 @@ func (a rsa_sha256) Verify(key interface{}, data, sig []byte) error {
 	return RSAVerify(k, crypto.SHA256, data, sig)
 }
 
+// HS2019 implements RSA PSS signatures over a SHA512 digest
+var HS2019 Algorithm = hs_2019{}
+
+type hs_2019 struct{}
+
+func (hs_2019) Name() string {
+	return "hs2019"
+}
+
+func (a hs_2019) Sign(key interface{}, data []byte) ([]byte, error) {
+	k := toRSAPrivateKey(key)
+	if k == nil {
+		return nil, unsupportedAlgorithm(a)
+	}
+	return RSASign(k, crypto.SHA512, data)
+}
+
+func (a hs_2019) Verify(key interface{}, data, sig []byte) error {
+	k := toRSAPublicKey(key)
+	if k == nil {
+		return unsupportedAlgorithm(a)
+	}
+	return RSAVerify(k, crypto.SH, data, sig)
+}
+
 // RSASign signs a digest of the data hashed using the provided hash
 func RSASign(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
 	signature []byte, err error) {

--- a/rsa.go
+++ b/rsa.go
@@ -69,8 +69,6 @@ func (a rsa_sha256) Verify(key interface{}, data, sig []byte) error {
 	return RSAVerify(k, crypto.SHA256, data, sig)
 }
 
-
-
 // RSASign signs a digest of the data hashed using the provided hash
 func RSASign(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
 	signature []byte, err error) {

--- a/rsa.go
+++ b/rsa.go
@@ -69,30 +69,7 @@ func (a rsa_sha256) Verify(key interface{}, data, sig []byte) error {
 	return RSAVerify(k, crypto.SHA256, data, sig)
 }
 
-// HS2019 implements RSA PSS signatures over a SHA512 digest
-var HS2019 Algorithm = hs_2019{}
 
-type hs_2019 struct{}
-
-func (hs_2019) Name() string {
-	return "hs2019"
-}
-
-func (a hs_2019) Sign(key interface{}, data []byte) ([]byte, error) {
-	k := toRSAPrivateKey(key)
-	if k == nil {
-		return nil, unsupportedAlgorithm(a)
-	}
-	return RSASignPSS(k, crypto.SHA512, data)
-}
-
-func (a hs_2019) Verify(key interface{}, data, sig []byte) error {
-	k := toRSAPublicKey(key)
-	if k == nil {
-		return unsupportedAlgorithm(a)
-	}
-	return RSAVerifyPSS(k, crypto.SHA512, data, sig)
-}
 
 // RSASign signs a digest of the data hashed using the provided hash
 func RSASign(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
@@ -114,28 +91,4 @@ func RSAVerify(key *rsa.PublicKey, hash crypto.Hash, data, sig []byte) (
 		return err
 	}
 	return rsa.VerifyPKCS1v15(key, hash, h.Sum(nil), sig)
-}
-
-// RSASignPSS signs a digest of the data hashed using the provided hash
-func RSASignPSS(key *rsa.PrivateKey, hash crypto.Hash, data []byte) (
-	signature []byte, err error) {
-
-	h := hash.New()
-	if _, err := h.Write(data); err != nil {
-		return nil, err
-	}
-	//TODO: Derive signing algorithm from keyID?
-	return rsa.SignPSS(Rand, key, hash, h.Sum(nil), nil)
-}
-
-// RSAVerifyPSS verifies a signed digest of the data hashed using the provided hash
-func RSAVerifyPSS(key *rsa.PublicKey, hash crypto.Hash, data, sig []byte) (
-	err error) {
-
-	h := hash.New()
-	if _, err := h.Write(data); err != nil {
-		return err
-	}
-	//TODO: Derive signing algorithm from keyID?
-	return rsa.VerifyPSS(key, hash, h.Sum(nil), sig, nil)
 }

--- a/sign.go
+++ b/sign.go
@@ -41,7 +41,7 @@ func NewSigner(id string, key interface{}, algo Algorithm, headers []string) (
 		algo: algo,
 	}
 
-	if algo.Name() != "hs2019" {
+	if !strings.Contains(algo.Name(), "hs2019") {
 		fmt.Printf("Algorithm %s is deprecated, please update to 'hs2019'", algo.Name())
 	}
 
@@ -79,9 +79,9 @@ func NewHMACSHA256Signer(id string, key []byte, headers []string) (
 
 // NewHS2019Signer contructs a signer with the specified key id, hmac key,
 // and headers to sign.
-func NewHS2019Signer(id string, key *rsa.PrivateKey, headers []string) (
+func NewHS2019PSSSigner(id string, key *rsa.PrivateKey, headers []string) (
 	signer *Signer) {
-	return NewSigner(id, key, HS2019, headers)
+	return NewSigner(id, key, HS2019_PSS, headers)
 }
 
 // Sign signs an http request and adds the signature to the authorization header

--- a/sign.go
+++ b/sign.go
@@ -73,6 +73,13 @@ func NewHMACSHA256Signer(id string, key []byte, headers []string) (
 	return NewSigner(id, key, HMACSHA256, headers)
 }
 
+// NewHS2019Signer contructs a signer with the specified key id, hmac key,
+// and headers to sign.
+func NewHS2019Signer(id string, key *rsa.PrivateKey, headers []string) (
+	signer *Signer) {
+	return NewSigner(id, key, HS2019, headers)
+}
+
 // Sign signs an http request and adds the signature to the authorization header
 func (r *Signer) Sign(req *http.Request) error {
 	params, err := signRequest(r.id, r.key, r.algo, r.headers, req)

--- a/sign.go
+++ b/sign.go
@@ -77,7 +77,7 @@ func NewHMACSHA256Signer(id string, key []byte, headers []string) (
 	return NewSigner(id, key, HMACSHA256, headers)
 }
 
-// NewHS2019Signer contructs a signer with the specified key id, hmac key,
+// NewHS2019PSSSigner constructs a signer with the specified key id, hmac key,
 // and headers to sign.
 func NewHS2019PSSSigner(id string, key *rsa.PrivateKey, headers []string) (
 	signer *Signer) {

--- a/sign.go
+++ b/sign.go
@@ -41,6 +41,10 @@ func NewSigner(id string, key interface{}, algo Algorithm, headers []string) (
 		algo: algo,
 	}
 
+	if algo.Name() != "hs2019" {
+		fmt.Printf("Algorithm %s is deprecated, please update to 'hs2019'", algo.Name())
+	}
+
 	// copy the headers slice, lowercasing as necessary
 	if len(headers) == 0 {
 		headers = []string{"(request-target)", "date"}

--- a/sign.go
+++ b/sign.go
@@ -79,9 +79,9 @@ func NewHMACSHA256Signer(id string, key []byte, headers []string) (
 
 // NewHS2019PSSSigner constructs a signer with the specified key id, hmac key,
 // and headers to sign.
-func NewHS2019PSSSigner(id string, key *rsa.PrivateKey, headers []string) (
+func NewHS2019PSSSigner(id string, key *rsa.PrivateKey, headers []string, saltLength int) (
 	signer *Signer) {
-	return NewSigner(id, key, HS2019_PSS, headers)
+	return NewSigner(id, key, NewHS2019_PSS(saltLength), headers)
 }
 
 // Sign signs an http request and adds the signature to the authorization header

--- a/verify.go
+++ b/verify.go
@@ -112,6 +112,13 @@ header_check:
 				params.Algorithm, params.KeyId)
 		}
 		return HMACVerify(hmac_key, crypto.SHA256, sig_data, params.Signature)
+	case "hs2019":
+		rsa_pubkey := toRSAPublicKey(key)
+		if rsa_pubkey == nil {
+			return fmt.Errorf("algorithm %q is not supported by key %q",
+				params.Algorithm, params.KeyId)
+		}
+		return RSAVerifyPSS(rsa_pubkey, crypto.SHA512, sig_data, params.Signature)
 	default:
 		return fmt.Errorf("unsupported algorithm %q", params.Algorithm)
 	}
@@ -182,7 +189,7 @@ func getParams(req *http.Request, header, prefix string) *Params {
 func parseAlgorithm(s string) (algorithm string, ok bool) {
 	s = strings.TrimSpace(s)
 	switch s {
-	case "rsa-sha1", "rsa-sha256", "hmac-sha256":
+	case "rsa-sha1", "rsa-sha256", "hmac-sha256", "hs2019":
 		return s, true
 	}
 	return "", false

--- a/verify.go
+++ b/verify.go
@@ -86,7 +86,7 @@ header_check:
 	if key == nil {
 		return fmt.Errorf("no key with id %q", params.KeyId)
 	}
-	keyAlgorithm := v.key_getter.GetAlgorithm(params.KeyId)
+	keyAlgorithm := v.key_getter.GetKeyAlgorithm(params.KeyId)
 	if params.Algorithm == "hs2019" && keyAlgorithm == nil {
 		return fmt.Errorf("no key algorithm with id %q", params.KeyId)
 	}

--- a/verify.go
+++ b/verify.go
@@ -112,7 +112,7 @@ header_check:
 				params.Algorithm, params.KeyId)
 		}
 		return HMACVerify(hmac_key, crypto.SHA256, sig_data, params.Signature)
-	case "hs2019":
+	case "hs2019_pss":
 		rsa_pubkey := toRSAPublicKey(key)
 		if rsa_pubkey == nil {
 			return fmt.Errorf("algorithm %q is not supported by key %q",
@@ -189,7 +189,7 @@ func getParams(req *http.Request, header, prefix string) *Params {
 func parseAlgorithm(s string) (algorithm string, ok bool) {
 	s = strings.TrimSpace(s)
 	switch s {
-	case "rsa-sha1", "rsa-sha256", "hmac-sha256", "hs2019":
+	case "rsa-sha1", "rsa-sha256", "hmac-sha256", "hs2019_pss":
 		return s, true
 	}
 	return "", false


### PR DESCRIPTION
Try implementing hs2019 support (using PSS).

I've been reading through both these drafts:
* https://tools.ietf.org/html/draft-cavage-http-signatures-12
* https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00

But still find it a bit confusing on how the digital signature algorithm should be derived from keyId in a good way both at the client and at the server side (funny the same confusion is stated in this [appendix B.1.1.1](https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#appendix-B))

Right now I've only added support for PSS algorithm, other algorithms can simply be added by creating new structs in the `hs2019.go` file. I was thinking that as the client will chose the algorithm and use the correct `hs2019` struct, the server can then look up the algorithm in the `KeyGetter` implementing struct (just like for the key data) and verify the signature using the new `GetKeyAlgorithm` function (this will be a breaking change for structs implementing this interface today, the whole new draft version feels a bit breaking with the new way of specifying the algorithm).

Hope I haven't misunderstood the new draft version completely, all change requests and help is appreciated.

Related issue: https://github.com/spacemonkeygo/httpsig/issues/7

As all the other algorithms have now become deprecated it would probably be a good idea to remove them entirely. But in order to not introduce even more breaking changes I've kept them and just added a deprecation message to update the algorithm to `hs2019` if any other version is used. Guess this will also collide with https://github.com/spacemonkeygo/httpsig/pull/6

The removal can then be done in a second step (after users of this lib get some time to migrate to the new algorithm)